### PR TITLE
Removed 'doozie' from adjectives because it is not an adjective

### DIFF
--- a/R/adjective.R
+++ b/R/adjective.R
@@ -32,7 +32,6 @@ adjective <- c(
   "delightful",
   "distinctive",
   "divine",
-  "doozie",
   "dope",
   "elegant",
   "epic",


### PR DESCRIPTION
'Doozie' is a noun to begin with, and although the way people use it sometimes is like an adjective, they still put the indefinite article in front of it, e.g., "That's a doozie!"  

But even with the indefinite, it's not going to work in all the same places an adjective will. If you wanted to say "You're such a ${adjective} person!", neither "a doozie" or "doozie" is going to make sense.