### PR TITLE
Removed 'callipygian' from adjective list

### DIFF
--- a/R/adjective.R
+++ b/R/adjective.R
@@ -16,7 +16,6 @@ adjective <- c(
   "breathtaking",
   "brightest",
   "brilliant",
-  "callipygian",
   "charming",
   "clever",
   "chic",

--- a/R/adjective.R
+++ b/R/adjective.R
@@ -32,7 +32,6 @@ adjective <- c(
   "delightful",
   "distinctive",
   "divine",
-  "doozie",
   "dope",
   "elegant",
   "epic",


### PR DESCRIPTION
In plain terms, 'callipygian' means "having a nice ass," which seemed like it could be inappropriate in certain contexts.