### PR TITLE
Remove adjective 'peculiar'

### DIFF
--- a/R/adjective.R
+++ b/R/adjective.R
@@ -89,7 +89,6 @@ adjective <- c(
   "outstanding",
   "particular",
   "peachy",
-  "peculiar",
   "perfect",
   "phenomenal",
   "pioneering",


### PR DESCRIPTION
Because it just doesn't fit in.